### PR TITLE
replace `st.experimental_rerun` with `st.rerun`

### DIFF
--- a/streamlit_login_auth_ui/widgets.py
+++ b/streamlit_login_auth_ui/widgets.py
@@ -116,7 +116,7 @@ class __login__:
                         self.cookies['__streamlit_login_signup_ui_username__'] = username
                         self.cookies.save()
                         del_login.empty()
-                        st.experimental_rerun()
+                        st.rerun()
 
 
     def animation(self) -> None:
@@ -243,7 +243,7 @@ class __login__:
                 st.session_state['LOGGED_IN'] = False
                 self.cookies['__streamlit_login_signup_ui_username__'] = '1c9a923f-fb21-4a91-b3f3-5f18e3f01182'
                 del_logout.empty()
-                st.experimental_rerun()
+                st.rerun()
         
 
     def nav_sidebar(self):


### PR DESCRIPTION
Replace `st.experimental_rerun` with `st.rerun`.
`st.experimental_rerun` will be removed after 2024-04-01.